### PR TITLE
Refacto reduce_ranges for performance

### DIFF
--- a/lib/reduce_ranges.rb
+++ b/lib/reduce_ranges.rb
@@ -4,15 +4,13 @@ class Array
   def reduce_ranges
     raise TypeError unless all? { |el| el.is_a?(Fixnum) }
 
-    arr = self.dup
-    arr.each_with_index do |el, index|
-      range_index = index + 1
-      prev = el
-      while arr[range_index] == prev + 1 do
-        prev = arr[range_index]
-        range_index += 1
-      end
-      arr[index..range_index-1] = (arr[index]..arr[range_index-1]) unless index == range_index - 1
+    results = []
+    temp = [self[0]]
+    self[1..-1].each do |e|
+      temp << e && next if temp.last == e - 1
+      results << (temp[1] ? (temp[0]..temp.last) : temp[0])
+      temp = [e]
     end
+    results << (temp[1] ? (temp[0]..temp.last) : temp[0])
   end
 end


### PR DESCRIPTION
A [french blogger](http://lkdjiin.github.io/blog/2014/06/30/exercice-ruby-reduce-ranges/) has launch a small exercise with your algorithm as purpose. The goal was first to made it works, and then, to do the most efficient.

I'm here to propose you my solution with some benchmarks :

``` ruby
array = [1, 2, 3, 7, 9, 17, 18, 19, 20]

Benchmark.bmbm do |x|
  x.report('calyhre') { 100_000.times { array.reduce_ranges } }
  x.report('original') { 100_000.times { array.reduce_ranges } }
end

# Rehearsal --------------------------------------------
# calyhre    0.440000   0.000000   0.440000 (  0.437160)
# original   0.510000   0.000000   0.510000 (  0.511847)
# ----------------------------------- total: 0.950000sec
#
#                user     system      total        real
# calyhre    0.440000   0.000000   0.440000 (  0.435045)
# original   0.490000   0.010000   0.500000 (  0.485511)

```
